### PR TITLE
Add Cloudflare CD workflow

### DIFF
--- a/.github/workflows/cloudflare-cd.yml
+++ b/.github/workflows/cloudflare-cd.yml
@@ -1,0 +1,129 @@
+name: Cloudflare CD
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: cloudflare-cd-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CI: '1'
+  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.16.0'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chrome
+        run: npx playwright install --with-deps chrome
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm run test
+
+      - name: Structural tests
+        run: npm run test:struct
+
+      - name: End-to-end tests
+        run: npm run test:e2e
+
+      - name: Deployment config check
+        run: npm run deploy:check
+
+  preview:
+    name: Cloudflare preview
+    runs-on: ubuntu-latest
+    needs: validate
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.16.0'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply preview D1 migrations
+        run: npx wrangler d1 migrations apply DB --env preview --remote
+
+      - name: Bootstrap preview D1 seed rows
+        run: npx tsx src/db/seed-cloudflare.ts --remote --bootstrap --wrangler-env=preview
+
+      - name: Build preview Worker assets
+        run: CLOUDFLARE_ENV=preview npm run build
+
+      - name: Deploy Cloudflare preview Worker
+        id: deploy
+        run: |
+          set -euo pipefail
+          npx wrangler deploy --config dist/we_do/wrangler.json --env="" --message "PR #${{ github.event.pull_request.number }} preview for ${GITHUB_SHA}"
+          preview_url="https://we-do-preview.jessmartin.workers.dev"
+          echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
+          echo "Cloudflare preview: $preview_url" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment preview URL
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" --body "Cloudflare Worker preview: ${PREVIEW_URL}"
+
+  production:
+    name: Cloudflare production
+    runs-on: ubuntu-latest
+    needs: validate
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.16.0'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply remote D1 migrations
+        run: npm run db:migrate:remote
+
+      - name: Bootstrap remote D1 seed rows
+        run: npm run db:seed:remote
+
+      - name: Deploy production Worker
+        run: npm run deploy:prod

--- a/README.md
+++ b/README.md
@@ -63,8 +63,11 @@ Production is deployed to:
 
 - https://wedo.sociotechnica.org
 
-Cloudflare deployment instructions live in
-`docs/deployment/cloudflare.md`. The checked-in flow is:
+Pull requests deploy a Cloudflare preview Worker, and merges to `main`
+automatically deploy production through GitHub Actions. Cloudflare deployment
+instructions live in `docs/deployment/cloudflare.md`.
+
+The manual deploy flow remains available for trusted local repair work:
 
 ```bash
 npm run deploy:check

--- a/docs/deployment/cloudflare.md
+++ b/docs/deployment/cloudflare.md
@@ -27,6 +27,21 @@ one family-scoped Durable Object namespace, and the production custom domain
 
 ## Deploy Flow
 
+Production deploys automatically from GitHub after a pull request merges to
+`main`. Pull requests deploy the `preview` Wrangler environment to
+`https://we-do-preview.jessmartin.workers.dev` and comment that preview URL
+back on the PR. The preview environment uses its own D1 database
+(`we-do-preview`) and stub natural-language parsing, so preview smoke tests do
+not mutate production household data or require the production Anthropic secret.
+
+The workflow requires these GitHub Actions secrets:
+
+- `CLOUDFLARE_ACCOUNT_ID`
+- `CLOUDFLARE_API_TOKEN`
+
+The manual deploy flow is still available when you need to repair or inspect a
+deploy from a trusted local machine:
+
 1. Validate the checked-in deploy configuration:
    - `npm run deploy:check`
 2. Apply the remote schema:

--- a/docs/plans/cd-workflow-proof/plan.md
+++ b/docs/plans/cd-workflow-proof/plan.md
@@ -1,0 +1,74 @@
+# CD Workflow Proof Plan
+
+## Goal
+
+Prove that WeDo has a real Cloudflare continuous deployment path: a pull request creates a preview Worker deployment, the preview is smoke-tested at its Cloudflare URL, merging the pull request deploys production, and the visible change appears at `https://wedo.sociotechnica.org`.
+
+## Scope
+
+- Add GitHub Actions automation for pull request validation, Cloudflare Worker preview deploys, and production deploys from `main`.
+- Configure the repository with the Cloudflare credentials needed by the workflow.
+- Make one small observable UI copy change that is safe to ship and easy to verify in preview and production.
+- Open a PR, observe the preview deployment, test it, merge the PR, observe the production deployment, and test the live app.
+
+## Non-Goals
+
+- No auth, login, or multi-household work.
+- No database schema changes.
+- No Durable Object or D1 behavior changes beyond running existing safe migrations and bootstrap seed commands in the deploy workflow.
+- No redesign of the watercolor/letterpress UI.
+
+## Current Context
+
+- ADR 001 requires Cloudflare as the sole infrastructure platform.
+- ADR 003 makes D1 the source of truth; deployment automation must not reset production data.
+- ADR 004 requires the Anthropic API key to remain server-side as a Worker secret.
+- The repo currently has no `.github/workflows` automation, so merging to `main` does not deploy by itself.
+- Worker version preview aliases are not usable for this app in the current account state because uploaded versions report `has_preview: false`; the PR preview should therefore use an explicit `preview` Wrangler environment with a separate Worker and D1 database.
+
+## Affected Layers And Boundaries
+
+- CI/CD config lives under `.github/workflows/` and uses existing package scripts.
+- Deployment docs live under `docs/deployment/`.
+- The observable smoke marker is a small UI copy change in the UI layer only.
+- No UI code imports from workers, realtime, or db layers; structural tests remain the boundary proof.
+
+## Slice Strategy
+
+This is one PR because the workflow and the observable smoke marker must be tested together to prove the CD path. The workflow is reviewable on its own: it runs existing gates, uploads a preview for PRs, and deploys production only from `main`.
+
+## Implementation Steps
+
+1. Add a GitHub Actions workflow for validation, PR preview deploy, and production deploy.
+2. Add a short deployment docs section describing the CD path and required secrets.
+3. Add a small visible UI copy change for preview/production verification.
+4. Set required GitHub secrets for Cloudflare deployment without committing secret values.
+5. Open a PR and wait for the preview workflow to complete.
+6. Smoke-test the preview Cloudflare URL.
+7. Merge the PR and wait for the production workflow to complete.
+8. Smoke-test `https://wedo.sociotechnica.org` and verify the copy change is live.
+
+## Tests And Acceptance Scenarios
+
+- `npm run typecheck`
+- `npm run lint`
+- `npm run test`
+- `npm run test:struct`
+- `npm run deploy:check`
+- GitHub PR workflow completes successfully.
+- PR preview URL loads the app and shows the smoke-marker copy.
+- Production workflow completes after merge.
+- Production URL loads the app, shows the smoke-marker copy, and still supports a basic task-toggle smoke check.
+
+## Risks And Open Questions
+
+- GitHub Actions needs a Cloudflare token with Workers, D1, routes, and secrets-compatible deploy access.
+- The preview Worker uses `https://we-do-preview.jessmartin.workers.dev`.
+- Production deploys run safe migrations and bootstrap seeding; they must not destructively reseed D1.
+
+## Exit Criteria
+
+- A PR creates a Cloudflare preview deployment and that preview is browser-tested.
+- Merging the PR triggers a production Cloudflare deployment.
+- The merged visible change is verified live on `https://wedo.sociotechnica.org`.
+- Repo documentation explains the CD workflow and required secrets.

--- a/src/db/seed-cloudflare.ts
+++ b/src/db/seed-cloudflare.ts
@@ -21,6 +21,7 @@ export type SeedMode = (typeof seedModeValues)[number];
 export type SeedOptions = {
   mode: SeedMode;
   target: SeedTarget;
+  wranglerEnv?: string;
 };
 
 type BuildWranglerCommandOptions = {
@@ -66,6 +67,26 @@ function isSeedTarget(value: string): value is SeedTarget {
 
 function isSeedMode(value: string): value is SeedMode {
   return seedModeValues.includes(value as SeedMode);
+}
+
+function parseWranglerEnvFromArgs(
+  args: ReadonlyArray<string>,
+): string | undefined {
+  const requestedEnvironments = args.flatMap((argument) => {
+    const envMatch = argument.match(/^--wrangler-env=([a-zA-Z0-9_-]+)$/);
+
+    return envMatch?.[1] ? [envMatch[1]] : [];
+  });
+
+  const uniqueEnvironments = [...new Set(requestedEnvironments)];
+
+  if (uniqueEnvironments.length > 1) {
+    throw new Error(
+      `Conflicting Wrangler environments provided: ${uniqueEnvironments.join(', ')}.`,
+    );
+  }
+
+  return uniqueEnvironments[0];
 }
 
 export function getDefaultSeedModeForTarget(target: SeedTarget): SeedMode {
@@ -154,15 +175,19 @@ export function parseSeedOptionsFromArgs(
     throw new Error('Reset seed mode is only available for local D1.');
   }
 
+  const wranglerEnv = parseWranglerEnvFromArgs(args);
+
   return {
     mode,
     target,
+    ...(wranglerEnv ? { wranglerEnv } : {}),
   };
 }
 
 export function buildWranglerSeedArgs(
   sqlFilePath: string,
   target: SeedTarget,
+  wranglerEnv?: string,
 ): string[] {
   const locationFlag =
     target === 'remote'
@@ -171,7 +196,18 @@ export function buildWranglerSeedArgs(
         ? '--preview'
         : '--local';
 
-  return ['d1', 'execute', 'DB', locationFlag, '--file', sqlFilePath, '--yes'];
+  const environmentArgs = wranglerEnv ? ['--env', wranglerEnv] : [];
+
+  return [
+    'd1',
+    'execute',
+    'DB',
+    ...environmentArgs,
+    locationFlag,
+    '--file',
+    sqlFilePath,
+    '--yes',
+  ];
 }
 
 export function buildSeedSqlForTarget(
@@ -212,16 +248,17 @@ async function runWrangler(args: string[]): Promise<void> {
 export async function seedCloudflareDatabase(
   target: SeedTarget = 'local',
   mode: SeedMode = getDefaultSeedModeForTarget(target),
+  wranglerEnv?: string,
 ): Promise<void> {
   const tempDir = await mkdtemp(join(tmpdir(), 'wedo-d1-seed-'));
   const sqlFile = join(tempDir, 'seed.sql');
 
   try {
     await writeFile(sqlFile, buildSeedSqlForTarget(target, mode), 'utf8');
-    await runWrangler(buildWranglerSeedArgs(sqlFile, target));
+    await runWrangler(buildWranglerSeedArgs(sqlFile, target, wranglerEnv));
 
     process.stdout.write(
-      `Seeded ${target} D1 in ${mode} mode with ${martinSeedData.persons.length} persons, ${martinSeedData.tasks.length} tasks, and ${martinSeedData.streaks.length} streak rows.\n`,
+      `Seeded ${wranglerEnv ? `${wranglerEnv} ` : ''}${target} D1 in ${mode} mode with ${martinSeedData.persons.length} persons, ${martinSeedData.tasks.length} tasks, and ${martinSeedData.streaks.length} streak rows.\n`,
     );
   } finally {
     await rm(tempDir, { force: true, recursive: true });
@@ -231,10 +268,12 @@ export async function seedCloudflareDatabase(
 if (process.argv[1] === thisFilePath) {
   const options = parseSeedOptionsFromArgs(process.argv.slice(2));
 
-  void seedCloudflareDatabase(options.target, options.mode).catch(
-    (error: unknown) => {
-      console.error(error);
-      process.exitCode = 1;
-    },
-  );
+  void seedCloudflareDatabase(
+    options.target,
+    options.mode,
+    options.wranglerEnv,
+  ).catch((error: unknown) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
 }

--- a/src/ui/routes/dashboard-route.tsx
+++ b/src/ui/routes/dashboard-route.tsx
@@ -17,14 +17,19 @@ export function DashboardRoute() {
       <div className="mx-auto flex max-w-[92rem] flex-col gap-6">
         <header className="px-1 py-1 md:px-2">
           <div className="grid gap-4 md:grid-cols-[auto_minmax(20rem,1fr)_auto] md:items-start">
-            <h1 className="hand-title text-[2.4rem] leading-none text-[var(--color-ink)] lg:text-[3rem]">
-              <Link
-                className="text-[var(--color-ink)] no-underline"
-                to={buildDayHref('/', board.day.date, todayDate)}
-              >
-                WeDo
-              </Link>
-            </h1>
+            <div>
+              <p className="scribe-label mb-1 text-[0.64rem] uppercase tracking-[0.32em] text-[var(--color-ink-soft)]">
+                Shared family board
+              </p>
+              <h1 className="hand-title text-[2.4rem] leading-none text-[var(--color-ink)] lg:text-[3rem]">
+                <Link
+                  className="text-[var(--color-ink)] no-underline"
+                  to={buildDayHref('/', board.day.date, todayDate)}
+                >
+                  WeDo
+                </Link>
+              </h1>
+            </div>
 
             <DayNavigation
               currentDate={board.day.date}

--- a/tests/unit/db/seed-cloudflare.test.ts
+++ b/tests/unit/db/seed-cloudflare.test.ts
@@ -72,6 +72,30 @@ describe('seed cloudflare mode parsing', () => {
       parseSeedOptionsFromArgs(['--remote', '--reset']),
     ).toThrowError(/only available for local d1/i);
   });
+
+  it('accepts a Wrangler environment for named Cloudflare environments', () => {
+    expect(
+      parseSeedOptionsFromArgs([
+        '--remote',
+        '--bootstrap',
+        '--wrangler-env=preview',
+      ]),
+    ).toEqual({
+      mode: 'bootstrap',
+      target: 'remote',
+      wranglerEnv: 'preview',
+    });
+  });
+
+  it('rejects conflicting Wrangler environments', () => {
+    expect(() =>
+      parseSeedOptionsFromArgs([
+        '--remote',
+        '--wrangler-env=preview',
+        '--wrangler-env=staging',
+      ]),
+    ).toThrowError(/conflicting wrangler environments/i);
+  });
 });
 
 describe('seed cloudflare wrangler arguments', () => {
@@ -93,6 +117,22 @@ describe('seed cloudflare wrangler arguments', () => {
     );
     expect(buildWranglerSeedArgs('/tmp/seed.sql', 'preview')).toContain(
       '--preview',
+    );
+  });
+
+  it('adds the Wrangler environment before the location flag', () => {
+    expect(buildWranglerSeedArgs('/tmp/seed.sql', 'remote', 'preview')).toEqual(
+      [
+        'd1',
+        'execute',
+        'DB',
+        '--env',
+        'preview',
+        '--remote',
+        '--file',
+        '/tmp/seed.sql',
+        '--yes',
+      ],
     );
   });
 });

--- a/tests/unit/ui/board-route.test.tsx
+++ b/tests/unit/ui/board-route.test.tsx
@@ -119,7 +119,7 @@ describe('Board routes', () => {
     expect(markup).toContain('href="/"');
     expect(markup).toContain('data-testid="day-skip-toggle"');
     expect(markup).toContain('SKIP DAY');
-    expect(markup).not.toContain('Shared family board');
+    expect(markup).toContain('Shared family board');
     expect(markup).not.toContain('stays visible in one calm glance');
     expect(markup).not.toContain('>Day<');
   });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,6 +5,7 @@
   "compatibility_flags": ["nodejs_compat"],
   "main": "./worker.ts",
   "workers_dev": true,
+  "preview_urls": true,
   "routes": [
     {
       "pattern": "wedo.sociotechnica.org",
@@ -71,6 +72,34 @@
       "vars": {
         "HOUSEHOLD_NAME": "Maple House",
         "TASK_PARSER_MODE": "live",
+        "TIMEZONE": "America/New_York",
+      },
+    },
+    "preview": {
+      "name": "we-do-preview",
+      "workers_dev": true,
+      "preview_urls": true,
+      "routes": [],
+      "durable_objects": {
+        "bindings": [
+          {
+            "name": "FAMILY_BOARD",
+            "class_name": "FamilyBoard",
+          },
+        ],
+      },
+      "d1_databases": [
+        {
+          "binding": "DB",
+          "database_name": "we-do-preview",
+          "database_id": "12441488-d85b-4dc2-9141-173a8387eeb5",
+          "preview_database_id": "12441488-d85b-4dc2-9141-173a8387eeb5",
+          "migrations_dir": "src/db/migrations",
+        },
+      ],
+      "vars": {
+        "HOUSEHOLD_NAME": "Maple House",
+        "TASK_PARSER_MODE": "stub",
         "TIMEZONE": "America/New_York",
       },
     },


### PR DESCRIPTION
## Summary
- add GitHub Actions validation, PR preview deploys, and production deploys from main
- add a dedicated Cloudflare preview Worker/D1 environment
- add a small visible dashboard marker for preview and production smoke testing
- document the automatic deployment path and production URL

## Local Verification
- npm run typecheck
- npm run lint
- npm run test
- npm run test:struct
- npm run deploy:check
- npm run test:e2e

## CD Proof Plan
This PR is intended to prove the real CD workflow: PR preview deploy, smoke test preview, merge, production deploy, and smoke test https://wedo.sociotechnica.org.